### PR TITLE
Using fixed version of Z3 and EMSCRIPTEN.

### DIFF
--- a/z3.sh
+++ b/z3.sh
@@ -197,7 +197,7 @@ EMCC_WASM_OPTIONS=(
     # Async compilation causes Firefox to infloop, repeatedly printing “still
     # waiting on run dependencies: dependency: wasm-instantiate”. We'll run
     # in a WebWorker anyway, so it wouldn't buy us much.
-    -s BINARYEN_ASYNC_COMPILATION=0)
+    -s WASM_ASYNC_COMPILATION=0)
 
 EMCC_Z3_JS_INPUTS=("${Z3_ROOT}build/z3.bc")
 EMCC_Z3_SMT2_JS_INPUTS=("${BASEDIR}z3smt2.c" "${Z3_ROOT}build/libz3.a")


### PR DESCRIPTION
Building the `Z3.wasm` with the current versions of the scripts and the dependencies does not work. I have adjusted the script to use particular versions of Z3 and EMSCRIPTEN to allow for  more predictable build results. This also fixes #4. 

Nevertheless, while the build seems to work fine up to a certain point, there is still a problem when building in the provided Vagrant environment: 

```
* Z3: Linking (slow!)
shared:ERROR: legacy setting used in strict mode: BINARYEN_ASYNC_COMPILATION
* Z3 smt2 client: Linking (slow!)
shared:ERROR: /home/vagrant/z3smt2.c: No such file or directory ("/home/vagrant/z3smt2.c" was expected to be an input file, based on the commandline arguments provided)
```